### PR TITLE
Fix Gravatar::param_cache typo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 composer.lock
 *.komodoproject
+.idea

--- a/Gravatar.php
+++ b/Gravatar.php
@@ -263,18 +263,18 @@ class Gravatar
 			}
 
 			// Stuff the request params into the param_cache property for later reuse
-			$this->params_cache = (!empty($params)) ? '?' . implode('&', $params) : '';
+			$this->param_cache = (!empty($params)) ? '?' . implode('&', $params) : '';
 		}
 
 		// Handle "null" gravatar requests.
 		$tail = '';
 		if(empty($email))
 		{
-			$tail = !empty($this->params_cache) ? '&f=y' : '?f=y';
+			$tail = !empty($this->param_cache) ? '&f=y' : '?f=y';
 		}
 
 		// And we're done.
-		return $url . $this->params_cache . $tail;
+		return $url . $this->param_cache . $tail;
 	}
 
 	/**


### PR DESCRIPTION
PHP 8.3  throws a deprecation:


`Deprecated: Creation of dynamic property App\Service\Gravatar\GravatarLib::$params_cache is deprecated in /app/vendor/thomaswelton/gravatarlib/thomaswelton/GravatarLib/Gravatar.php on line 266
`
